### PR TITLE
참여자 기록 보고서 API 추가

### DIFF
--- a/lib/zoom.rb
+++ b/lib/zoom.rb
@@ -15,6 +15,7 @@ require "zoom/objectified_hash"
 require "zoom/api/user"
 require "zoom/api/meeting"
 require "zoom/api/webinar"
+require "zoom/api/report"
 require "zoom/api/group"
 
 module Zoom

--- a/lib/zoom/api/report.rb
+++ b/lib/zoom/api/report.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Zoom # :nodoc:
+  module Api
+    # reports
+    class Report < Client
+      class << self
+        # Retrieve participants of a meeting.
+        def get_meeting_participants(meeting_id:, page_size: 300)
+          params = method(__method__).parameters.map(&:last).map { |p| [p, eval(p.to_s)] }.to_h
+          parse(JSON.parse(connection.get("report/meetings/#{meeting_id}/participants", params).body))
+        end
+
+        # Retrieve participants of a webinar.
+        def get_webinar_participants(webinar_id:, page_size: 300)
+          params = method(__method__).parameters.map(&:last).map { |p| [p, eval(p.to_s)] }.to_h
+          parse(JSON.parse(connection.get("report/webinars/#{webinar_id}/participants", params).body))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket:
[[참여자 기록] 운영툴 Zoom 참여자 기록 다운로드 기능 추가](https://3.basecamp.com/4366072/buckets/15258347/todos/3460644648)

API 문서:
https://marketplace.zoom.us/docs/api-reference/zoom-api/reports/reportmeetingparticipants
https://marketplace.zoom.us/docs/api-reference/zoom-api/reports/reportwebinarparticipants

Zoom 참여자 기록 API를 추가하였습니다.