### PR TITLE
add webinar panelists api

### DIFF
--- a/lib/zoom/api/webinar.rb
+++ b/lib/zoom/api/webinar.rb
@@ -20,6 +20,17 @@ module Zoom # :nodoc:
         def get_webinar(webinar_id:)
           parse(JSON.parse(connection.get("webinars/#{webinar_id}").body))
         end
+
+        # list all the panelists of a Webinar.
+        # {"total_records"=>1, "panelists"=>[{"id"=>"kBEzAe", "name"=>"panel", "email"=>"panel@add_panelists.test", "join_url"=>"https://us02web.zoom.us/**"}]}
+        def get_panelists(webinar_id:)
+          parse(JSON.parse(connection.get("webinars/#{webinar_id}/panelists").body))
+        end
+
+        # add panelists to a scheduled webinar.
+        def add_panelists(webinar_id:, params:)
+          parse(JSON.parse(connection.post("webinars/#{webinar_id}/panelists", params.to_json).body))
+        end
       end
     end
   end

--- a/test/zoom/api/webinar_test.rb
+++ b/test/zoom/api/webinar_test.rb
@@ -52,4 +52,26 @@ class WebinarTest < Minitest::Spec
     response = Zoom::Api::Webinar.get_webinar(webinar_id: 437659431)
     assert_equal params[:topic], response.topic
   end
+
+  it "get panelists" do
+    skip
+    response = Zoom::Api::Webinar.get_panelists(webinar_id: 437659431)
+    assert_equal response.status, 200
+  end
+
+  it "add panelists" do
+    skip
+
+    params = {
+      panelists: [
+        {
+          name: "panel",
+          email: "panel@test_add_panelists.test"
+        }
+      ]
+    }
+
+    response = Zoom::Api::Webinar.add_panelists(webinar_id: 437659431, params: params)
+    assert_equal response.status, 200
+  end
 end


### PR DESCRIPTION
add webinar panelists api
https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/webinarpanelistcreate
https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/webinarpanelists